### PR TITLE
Fixes #11

### DIFF
--- a/im/lxc-probes.d/cpu.sh
+++ b/im/lxc-probes.d/cpu.sh
@@ -19,7 +19,7 @@
 if [ -f /proc/cpuinfo ]; then
 
     echo -n "MODELNAME=\""
-    grep -m 1 "model name" /proc/cpuinfo | cut -d: -f2 | sed -e 's/^ *//' | sed -e 's/$/"/'
+    grep -m 1 -e "model name" -e "Hardware" /proc/cpuinfo | cut -d: -f2 | sed -e 's/^ *//' | sed -e 's/$/"/'
 
 fi
 


### PR DESCRIPTION
Extending the grep to match on the keyword "Hardware".
"Hardware" isn't part of what x86 outputs so there should be no direct negative consequences.
IF /proc/cpuinfo was ever fixed to output proper information on ARM (which is unlikely) it could produce duplicate output.
